### PR TITLE
Attachment 'ts' -- should be a String

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/model/Attachment.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Attachment.java
@@ -128,7 +128,7 @@ public class Attachment {
      * <p>
      * Use ts when referencing articles or happenings. Your message will have its own timestamp when published.
      */
-    private Integer ts;
+    private String ts;
 
     /**
      * By default,


### PR DESCRIPTION
'ts' values are more or less like -->  1498530147.464010
which is not an integer. So changing it to String instead of Integer --> keeping it consistent with the 'ts' attribute in the 'message' model